### PR TITLE
fix: update API URL to HuggingFace Spaces, fix README badge, add Google OAuth env docs

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=https://sentrix-api-production-1aec.up.railway.app
+VITE_API_BASE_URL=https://bionicop-sentrix-api.hf.space
 VITE_API_VERSION=v1
 VITE_API_TIMEOUT=30000
 VITE_USE_MOCK=false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sentrix UI
 
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-ui--bionics--projects.vercel.app-black?style=flat-square&logo=vercel)](https://ui-bionics-projects.vercel.app)
-[![API](https://img.shields.io/badge/API-Railway-blueviolet?style=flat-square&logo=railway)](https://sentrix-api-production-1aec.up.railway.app/api/v1/health)
+[![API](https://img.shields.io/badge/API-HuggingFace%20Spaces-orange?style=flat-square&logo=huggingface)](https://bionicop-sentrix-api.hf.space/api/v1/health)
 
 > **Live:** https://ui-bionics-projects.vercel.app
 
@@ -153,10 +153,12 @@ ui/src/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VITE_USE_MOCK` | `true` (dev) / `false` (prod) | Use mock data instead of real API |
-| `VITE_API_BASE_URL` | `http://localhost:8080` | API Gateway base URL |
+| `VITE_API_BASE_URL` | `http://localhost:8080` | API Gateway base URL (prod: `https://bionicop-sentrix-api.hf.space`) |
 | `VITE_API_VERSION` | `v1` | API version prefix |
 | `VITE_API_TIMEOUT` | `30000` | Request timeout (ms) |
 | `VITE_ENABLE_WEBSOCKET` | `false` | Enable WebSocket connection |
+| `VITE_ENABLE_GOOGLE_AUTH` | `false` | Enable Google OAuth button |
+| `VITE_GOOGLE_CLIENT_ID` | `` | Google OAuth client ID (required if auth enabled) |
 | `VITE_ALERT_POLLING_INTERVAL` | `30000` | Alert refresh interval (ms) |
 | `VITE_DASHBOARD_REFRESH_INTERVAL` | `30000` | Dashboard refresh interval (ms) |
 | `VITE_DEFAULT_THEME` | `system` | Default theme: `light`, `dark`, `system` |


### PR DESCRIPTION
## Summary

- Updates `VITE_API_BASE_URL` from Railway (retired) to HuggingFace Spaces (`https://bionicop-sentrix-api.hf.space`)
- Updates README badge from Railway to HuggingFace Spaces
- Adds `VITE_ENABLE_GOOGLE_AUTH` and `VITE_GOOGLE_CLIENT_ID` to environment variables table

## Test plan

- [ ] Verify production URL shows correct API endpoint after merge
- [ ] Confirm Vercel deployment picks up new env vars