### PR TITLE
feat: show linked alert ID in post-mortems table

### DIFF
--- a/src/pages/incidents/components/PostMortemTable.tsx
+++ b/src/pages/incidents/components/PostMortemTable.tsx
@@ -67,7 +67,7 @@ export const PostMortemTable = React.memo(function PostMortemTable({
       paginated.map((pm) => ({
         id: String(pm.id),
         title: pm.title || 'Untitled',
-        alert_id: pm.alert_id > 0 ? String(pm.alert_id) : '--',
+        alert_id: pm.alert_id_str || (pm.alert_id > 0 ? String(pm.alert_id) : '--'),
         root_cause_category: pm.root_cause_category || 'unknown',
         status: pm.status || 'draft',
         created_by: pm.created_by || '--',

--- a/src/shared/services/postMortemService.ts
+++ b/src/shared/services/postMortemService.ts
@@ -34,6 +34,7 @@ export interface ActionItem {
 export interface PostMortem {
   id: number;
   alert_id: number;
+  alert_id_str?: string;
   title: string;
   root_cause: string;
   root_cause_category: string;


### PR DESCRIPTION
## Summary
- PostMortemTable now prefers `alert_id_str` (string alert ID) over the numeric `alert_id` when rendering the Alert ID column
- PostMortem interface in postMortemService.ts extended with optional `alert_id_str` field

## Test plan
- [ ] Post-Mortems page shows real alert IDs (e.g. ALT-S001) for BGP/SFP/Memory post-mortems
- [ ] Clicking alert ID navigates to that alert's detail page
- [ ] Post-mortems without a linked alert still show `--`